### PR TITLE
Removed error handling from ID

### DIFF
--- a/dist/html.js
+++ b/dist/html.js
@@ -60,9 +60,6 @@ export default class Html {
    * @returns Html
    */
   id(val) {
-    if (this.elm.id != null) {
-      throw Error("The element already has an ID.");
-    }
     this.elm.id = val;
     return this;
   }

--- a/src/html.ts
+++ b/src/html.ts
@@ -60,9 +60,6 @@ export default class Html {
    * @returns Html
    */
   id(val: string): Html {
-    if(this.elm.id != null) {
-      throw Error("The element already has an ID.");
-    }
     this.elm.id = val;
     return this;
   }


### PR DESCRIPTION
I just realized the error thrown in `id()` doesn't really make sense. So I removed it.